### PR TITLE
Fix Search's next()

### DIFF
--- a/lib/DBIx/NoSQL/Search.pm
+++ b/lib/DBIx/NoSQL/Search.pm
@@ -143,6 +143,12 @@ sub next {
     my $cursor = $self->cursor;
     my $value = $cursor->next;
 
+    # cursor returns an arrayref, we want its first element
+    $value = $value->[0] if ref $value;
+
+    # nothing found? eject
+    return unless $value;
+
     if      ( $as eq 'object' ) { return $model->create_object( $value ) }
     elsif   ( $as eq 'entity' ) { return $model->create_entity( $value ) }
     elsif   ( $as eq 'data' ||

--- a/lib/DBIx/NoSQL/Storage.pm
+++ b/lib/DBIx/NoSQL/Storage.pm
@@ -128,15 +128,12 @@ sub next {
         $self->sth( $self->_select );
     }
 
-    my $row = $self->sth->fetchrow_arrayref;
-    if ( $row ) {
-    }
-    else {
+    my $row = $self->sth->fetchrow_arrayref or do {
         $self->sth( undef );
         $self->finished( 0 );
-    }
+    };
 
-    return $row;
+    return $row || [];
 }
 
 sub all {

--- a/t/06-synopsis.t
+++ b/t/06-synopsis.t
@@ -63,7 +63,7 @@ SKIP: {
     my $album = $store->get( 'Album' => 'Siamese Dream' );
     my $released = $album->{ released };
 
-    ok( blessed $released );
+    is ref($released ) => 'DateTime';
     is( $released->year, 1993 );
     is( $released->day, 1 );
 }

--- a/t/07-synopsis-NoSQLite.t
+++ b/t/07-synopsis-NoSQLite.t
@@ -64,7 +64,7 @@ SKIP: {
     my $album = $store->get( 'Album' => 'Siamese Dream' );
     my $released = $album->{ released };
 
-    ok( blessed $released );
+    is ref($released) => 'DateTime';
     is( $released->year, 1993 );
     is( $released->day, 1 );
 }

--- a/t/10-next.t
+++ b/t/10-next.t
@@ -1,0 +1,25 @@
+use strict;
+use warnings;
+
+use Test::More tests => 4;
+use t::Test;
+
+my $store_file = t::Test->tmp_sqlite;
+my $store = DBIx::NoSQL->connect( $store_file );
+ok( $store );
+
+$store->set('Artist' => 'Foo' => { bar => 'baz' } );
+
+my $rs = $store->search('Artist');
+
+my @all = $rs->all;
+my @next;
+
+while(my $artist = $rs->next ) {
+    push @next, $artist;
+}
+
+is @all => 1;
+is @next => 1;
+
+is_deeply \@all => \@next;


### PR DESCRIPTION
The next() method in the Cursor class is returning an arrayref,  which was not playing nicely with the inflation of the objects.
